### PR TITLE
[FT] Linker visbility added and minor HF

### DIFF
--- a/cmd/wio/commands/build/build.go
+++ b/cmd/wio/commands/build/build.go
@@ -91,6 +91,7 @@ func RunBuild(directoryCli string, targetCli string, cleanCli bool, port string)
         projectDependencies = types.DependenciesTag{pkgConfig.MainTag.Name: &types.DependencyTag{
             Version:         pkgConfig.MainTag.Version,
             Vendor:          false,
+            LinkVisibility:  "private",
             DependencyFlags: targetToBuild.GetFlags()["pkg_flags"],
         }}
     }

--- a/cmd/wio/config/meta.go
+++ b/cmd/wio/config/meta.go
@@ -10,7 +10,7 @@ type meta struct {
 
 var ProjectMeta = meta{
     Name:                 "wio",
-    Version:              "0.2.2",
+    Version:              "0.2.3",
     EnableBashCompletion: true,
     Copyright:            "Copyright (c) 2018 Waterloop",
     UsageText:            "Create, Build and Upload Embedded projects",

--- a/cmd/wio/dependencies/cmake-text-generator.go
+++ b/cmd/wio/dependencies/cmake-text-generator.go
@@ -43,11 +43,7 @@ func generateAvrDependencyCMakeString(targets map[string]*CMakeTarget, links []C
         finalString = strings.Replace(finalString, "{{LINKER_NAME}}", link.From, -1)
         finalString = strings.Replace(finalString, "{{DEPENDENCY_NAME}}", link.To, -1)
 
-        if link.HeaderOnly {
-            finalString = strings.Replace(finalString, "{{VISIBILITY}}", "INTERFACE", -1)
-        } else {
-            finalString = strings.Replace(finalString, "{{VISIBILITY}}", "PRIVATE", -1)
-        }
+        finalString = strings.Replace(finalString, "{{VISIBILITY}}", link.LinkVisibility, -1)
 
         cmakeStrings = append(cmakeStrings, finalString)
     }

--- a/cmd/wio/dependencies/dependency-parser.go
+++ b/cmd/wio/dependencies/dependency-parser.go
@@ -37,7 +37,7 @@ type CMakeTarget struct {
 type CMakeTargetLink struct {
     From       string
     To         string
-    HeaderOnly bool
+    LinkVisibility string
 }
 
 // Stores information about every package that is scanned
@@ -215,7 +215,7 @@ func CreateCMakeDependencies(projectName string, directory string, providedFlags
         }
 
         requiredFlags, err := createCMakeTargets(projectTarget, false, dependencyName, dependencyTargetName, dependencyTarget,
-            globalFlags, projectDependency.DependencyFlags)
+            globalFlags, projectDependency.DependencyFlags, projectDependency.LinkVisibility)
         if err != nil {
             return err
         }

--- a/cmd/wio/dependencies/flags.go
+++ b/cmd/wio/dependencies/flags.go
@@ -10,7 +10,7 @@ import (
 
 // Verifies the placeholder syntax
 func placeholderSyntaxValid(flag string) bool {
-    pat := regexp.MustCompile(`\$\([-a-zA-Z0-9=]+\)`)
+    pat := regexp.MustCompile(`\$\([a-zA-Z0-9=_-]+\)`)
     s := pat.FindString(flag)
 
     return s != ""
@@ -33,6 +33,8 @@ func fillPlaceholderFlags(providedFlags []string, desiredFlags []string, depende
             continue
         }
 
+        oldLength := len(newFlags)
+
         for _, providedFlag := range providedFlags {
             newFlag := strings.Replace(desiredFlag, "$", "", 1)
             newFlag = strings.Replace(newFlag, "(", "", 1)
@@ -42,12 +44,15 @@ func fillPlaceholderFlags(providedFlags []string, desiredFlags []string, depende
 
             if s != "" {
                 newFlags = append(newFlags, providedFlag)
-            } else {
-                log.Norm.Red(true, "Invalid placeholder reference")
-                log.Norm.Cyan(true, "  Dependency: "+dependencyName+"\t Placeholder: "+desiredFlag)
-
-                return nil, errors.New("invalid placeholder reference in " + dependencyName + " package")
+                break
             }
+        }
+
+        if len(newFlags) == oldLength {
+            log.Norm.Red(true, "Invalid placeholder reference")
+            log.Norm.Cyan(true, "  Dependency: "+dependencyName+"\t Placeholder: "+desiredFlag)
+
+            return nil, errors.New("invalid placeholder reference in " + dependencyName + " package")
         }
     }
 

--- a/cmd/wio/types/general-types.go
+++ b/cmd/wio/types/general-types.go
@@ -120,6 +120,7 @@ func (pkgTargetsTag PkgTargetsTag) GetTargets() map[string]Target {
 type DependencyTag struct {
     Version         string
     Vendor          bool
+    LinkVisibility  string   `yaml:"link_visibility"`
     DependencyFlags []string `yaml:"dependency_flags"`
 }
 

--- a/cmd/wio/utils/io/bindata.go
+++ b/cmd/wio/utils/io/bindata.go
@@ -185,7 +185,7 @@ func assetsTemplatesCmakeCmakelistsavrTxtTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "assets/templates/cmake/CMakeListsAVR.txt.tpl", size: 1369, mode: os.FileMode(420), modTime: time.Unix(1528652932, 0)}
+	info := bindataFileInfo{name: "assets/templates/cmake/CMakeListsAVR.txt.tpl", size: 1369, mode: os.FileMode(420), modTime: time.Unix(1528723045, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wio",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "An Embedded Development Environment",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Now user can define the linker visibility. This helps in the case where a dependency is included in the public header files and needs to be linked to the targets below. Example:
```yaml
dependencies:
  my-pkg:
    version: 2.1.3
    vendor: false
    link_visibility: "PUBLIC"
    dependency_flags: []

```
Supported visibilities are:
`PUBLIC`, `PRIVATE`, `INTERFACE` (header only packages)