### PR TITLE
Removing version ^

### DIFF
--- a/cmd/wio/commands/pac/pac.go
+++ b/cmd/wio/commands/pac/pac.go
@@ -107,7 +107,7 @@ func createPrivatePackageJson(directory string, name string, dependencies types.
     // add dependencies to package.json
     for dependencyName, dependencyValue := range dependencies {
         if !dependencyValue.Vendor {
-            npmConfig.Dependencies[dependencyName] = "^" + dependencyValue.Version
+            npmConfig.Dependencies[dependencyName] = dependencyValue.Version
         }
     }
 


### PR DESCRIPTION
Causing some issues with `latest` also this shouldn't be the default value... if the user wants version 1.0.2 or above let them specify that. You shouldn't be forcing their desired version or later. 