### PR TITLE
support for downloading remote dependencies from vendor packages

### DIFF
--- a/cmd/wio/commands/run/dependencies/dependencies.go
+++ b/cmd/wio/commands/run/dependencies/dependencies.go
@@ -175,7 +175,7 @@ func CreateCMakeDependencyTargets(
     projectFlags := (*target).GetFlags()
     projectDefinitions := (*target).GetDefinitions()
 
-    remotePackagesPath := io.Path(projectPath, io.Folder)
+    remotePackagesPath := io.Path(projectPath, io.Folder, io.Modules)
     vendorPackagesPath := io.Path(projectPath, io.Vendor)
 
     scannedDependencies := map[string]*DependencyScanStructure{}

--- a/cmd/wio/toolchain/npm/resolve/resolve.go
+++ b/cmd/wio/toolchain/npm/resolve/resolve.go
@@ -99,7 +99,7 @@ func (i *Info) ResolveRemote(config types.IConfig) error {
     deps := config.Dependencies()
     for name, ver := range deps {
         // only worry about remotes
-        if ver == io.Vendor+ver {
+        if strings.Contains(ver, io.Vendor) {
             continue
         }
 

--- a/cmd/wio/toolchain/npm/resolve/resolve.go
+++ b/cmd/wio/toolchain/npm/resolve/resolve.go
@@ -1,14 +1,64 @@
 package resolve
 
 import (
+    "strings"
+    "wio/cmd/wio/constants"
     "wio/cmd/wio/errors"
+    "wio/cmd/wio/log"
     "wio/cmd/wio/toolchain/npm/semver"
     "wio/cmd/wio/types"
+    "wio/cmd/wio/utils"
+    "wio/cmd/wio/utils/io"
 )
 
 const (
     Latest = "latest"
 )
+
+// Flattens vendor dependency graph and creates a map of remote dependency name and version.
+// An entry would like: "packageName__packageVersion: packageVersion"
+func FlattenVendorRemoteDependencies(queue *log.Queue, directory string, vendorRemotes map[string]string) error {
+    // parent config
+    parentConfig, err := utils.ReadWioConfig(directory)
+    if err != nil {
+        return err
+    }
+
+    for parentDependencyName, parentDependency := range parentConfig.GetDependencies() {
+        if parentDependency.Vendor {
+            currDirectory := io.Path(directory, io.Vendor, parentDependencyName)
+
+            if !utils.PathExists(currDirectory) {
+                return errors.Stringf("vendor dependency [%s] from [%s] does not exist",
+                    parentDependencyName, parentConfig.Name())
+            }
+
+            dependencyConfig, err := utils.ReadWioConfig(currDirectory)
+            if err != nil {
+                return err
+            }
+
+            if dependencyConfig.GetType() == constants.APP {
+                log.Warnln(queue, "vendor dependency [%s] is supposed to be a package. Skipping....",
+                    parentDependencyName)
+                continue
+            }
+
+            // go through it's dependencies to get all the remote ones
+            for depName, dep := range dependencyConfig.GetDependencies() {
+                if dep.Vendor {
+                    if err := FlattenVendorRemoteDependencies(queue, currDirectory, vendorRemotes); err != nil {
+                        return err
+                    }
+                } else {
+                    vendorRemotes[depName+"__"+dep.Version] = dep.Version
+                }
+            }
+        }
+    }
+
+    return nil
+}
 
 func (i *Info) GetLatest(name string) (string, error) {
     data, err := i.GetData(name)
@@ -42,13 +92,33 @@ func (i *Info) ResolveRemote(config types.IConfig) error {
 
     root := &Node{name: config.Name(), ver: config.Version()}
     if root.resolve = semver.Parse(root.ver); root.resolve == nil {
-        return errors.Stringf("project has invalid version %s", root.ver)
+        return errors.Stringf("project has an invalid version %s", root.ver)
     }
+
+    // remotes from main config file
     deps := config.Dependencies()
     for name, ver := range deps {
+        name = strings.Split(name, "__")[0]
+
         node := &Node{name: name, ver: ver}
         root.deps = append(root.deps, node)
     }
+
+    // remotes from all the vendors
+    queue := &log.Queue{}
+    vendorRemotes := map[string]string{}
+    if err := FlattenVendorRemoteDependencies(queue, i.dir, vendorRemotes); err != nil {
+        return err
+    }
+    for name, ver := range vendorRemotes {
+        name = strings.Split(name, "__")[0]
+
+        node := &Node{name: name, ver: ver}
+        root.deps = append(root.deps, node)
+    }
+    log.Writeln(queue)
+
+    // resolve remotes
     for _, dep := range root.deps {
         if err := i.ResolveTree(dep); err != nil {
             return err

--- a/cmd/wio/toolchain/npm/resolve/resolve.go
+++ b/cmd/wio/toolchain/npm/resolve/resolve.go
@@ -98,7 +98,13 @@ func (i *Info) ResolveRemote(config types.IConfig) error {
     // remotes from main config file
     deps := config.Dependencies()
     for name, ver := range deps {
-        name = strings.Split(name, "__")[0]
+        splitData := strings.Split(name, "__")
+        name := splitData[0]
+
+        // only worry about remotes
+        if splitData[1] == io.Vendor {
+            continue
+        }
 
         node := &Node{name: name, ver: ver}
         root.deps = append(root.deps, node)

--- a/cmd/wio/toolchain/npm/resolve/resolve.go
+++ b/cmd/wio/toolchain/npm/resolve/resolve.go
@@ -98,11 +98,8 @@ func (i *Info) ResolveRemote(config types.IConfig) error {
     // remotes from main config file
     deps := config.Dependencies()
     for name, ver := range deps {
-        splitData := strings.Split(name, "__")
-        name := splitData[0]
-
         // only worry about remotes
-        if splitData[1] == io.Vendor {
+        if ver == io.Vendor+ver {
             continue
         }
 

--- a/cmd/wio/types/general-types.go
+++ b/cmd/wio/types/general-types.go
@@ -284,7 +284,9 @@ type DependenciesTag map[string]*DependencyTag
 func (deps DependenciesTag) collect() map[string]string {
     depMap := map[string]string{}
     for name, dep := range deps {
-        depMap[name] = dep.Version
+        if !dep.Vendor {
+            depMap[name+"__"+dep.Version] = dep.Version
+        }
     }
     return depMap
 }

--- a/cmd/wio/types/general-types.go
+++ b/cmd/wio/types/general-types.go
@@ -281,13 +281,16 @@ type DependencyTag struct {
 // type for the libraries tag in the main wio.yml file
 type DependenciesTag map[string]*DependencyTag
 
+// creates a map of name and version for dependencies
+// for vendor dependency, value looks like: vendor<version> :: ex: vendor0.0.1
+// for remote dependencies, value looks like: <version> :: ex: 1.0.0
 func (deps DependenciesTag) collect() map[string]string {
     depMap := map[string]string{}
     for name, dep := range deps {
-        if !dep.Vendor {
-            depMap[name+"__"+dep.Version] = dep.Version
+        if dep.Vendor {
+            depMap[name] = io.Vendor + dep.Version
         } else {
-            depMap[name+"__"+io.Vendor] = dep.Version
+            depMap[name] = dep.Version
         }
     }
     return depMap

--- a/cmd/wio/types/general-types.go
+++ b/cmd/wio/types/general-types.go
@@ -286,6 +286,8 @@ func (deps DependenciesTag) collect() map[string]string {
     for name, dep := range deps {
         if !dep.Vendor {
             depMap[name+"__"+dep.Version] = dep.Version
+        } else {
+            depMap[name+"__"+io.Vendor] = dep.Version
         }
     }
     return depMap

--- a/tests/project-app/app-avr-vendor/.gitignore
+++ b/tests/project-app/app-avr-vendor/.gitignore
@@ -1,0 +1,36 @@
+# wio
+.wio/
+
+# Mac OS
+.DS_Store
+.DS_Store?
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Windows
+ehthumbs_vista.db
+[Dd]esktop.ini
+
+
+# C++ Prerequisites
+*.d
+
+# C++ Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# C++ Precompiled Headers
+*.gch
+*.pch
+
+# C++ Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll

--- a/tests/project-app/app-avr-vendor/README.md
+++ b/tests/project-app/app-avr-vendor/README.md
@@ -1,0 +1,8 @@
+# app-avr-vendor
+
+This is a wio avr application.
+
+To build this application:
+```bash
+wio run
+```

--- a/tests/project-app/app-avr-vendor/src/main.cpp
+++ b/tests/project-app/app-avr-vendor/src/main.cpp
@@ -1,0 +1,9 @@
+#include <jojo.h>
+#include <vendor1.h>
+#include <wlib/memory>
+
+void setup() {
+}
+
+void loop() {
+}

--- a/tests/project-app/app-avr-vendor/wio.yml
+++ b/tests/project-app/app-avr-vendor/wio.yml
@@ -24,11 +24,7 @@ targets:
       board: uno
 
 dependencies:
-  jojo:
-    version: 0.0.1
-    vendor: true
-    link_visibility: PRIVATE
-  vendor1:
+  pkg-list:
     version: 0.0.1
     vendor: true
     link_visibility: PRIVATE

--- a/tests/project-app/app-avr-vendor/wio.yml
+++ b/tests/project-app/app-avr-vendor/wio.yml
@@ -1,0 +1,38 @@
+app:
+  name: app-avr-vendor
+  ide: none
+
+  config:
+    minimum_wio_version: 0.3.2
+    supported_platforms:
+    - avr
+    supported_frameworks:
+    - cosa
+    supported_boards:
+    - uno
+
+  compile_options:
+    platform: avr
+
+targets:
+  default: main
+  create:
+    main:
+      src: src
+      platform: avr
+      framework: cosa
+      board: uno
+
+dependencies:
+  jojo:
+    version: 0.0.1
+    vendor: true
+    link_visibility: PRIVATE
+  vendor1:
+    version: 0.0.1
+    vendor: true
+    link_visibility: PRIVATE
+  wlib-memory:
+    version: 1.0.0
+    vendor: false
+    link_visibility: PRIVATE

--- a/tests/project-pkg/pkg-list/wio.yml
+++ b/tests/project-pkg/pkg-list/wio.yml
@@ -55,3 +55,7 @@ dependencies:
     link_visibility: PRIVATE
     definitions:
     - $(STACK_SIZE)
+  cosa-fart:
+    version: 0.0.1
+    vendor: false
+    link_visibility: PRIVATE

--- a/tests/project-pkg/pkg-list/wio.yml
+++ b/tests/project-pkg/pkg-list/wio.yml
@@ -55,7 +55,3 @@ dependencies:
     link_visibility: PRIVATE
     definitions:
     - $(STACK_SIZE)
-  cosa-fart:
-    version: 0.0.1
-    vendor: false
-    link_visibility: PRIVATE

--- a/tests/project-pkg/pkg-malloc/wio.yml
+++ b/tests/project-pkg/pkg-malloc/wio.yml
@@ -40,3 +40,9 @@ targets:
       definitions:
         pkg_definitions:
         - STACK_SIZE=256
+
+dependencies:
+  cosa-servo:
+    version: 1.0.0
+    vendor: false
+    link_visibility: PRIVATE

--- a/tests/project-pkg/pkg-malloc/wio.yml
+++ b/tests/project-pkg/pkg-malloc/wio.yml
@@ -40,9 +40,3 @@ targets:
       definitions:
         pkg_definitions:
         - STACK_SIZE=256
-
-dependencies:
-  cosa-servo:
-    version: 1.0.0
-    vendor: false
-    link_visibility: PRIVATE

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -4,7 +4,7 @@ set -e
 
 test_folder="wio-test"
 base_folder=$(pwd)
-num_tests=9
+num_tests=10
 
 # Check that working directory contains script
 if [ ! -f $(pwd)/`basename "$0"` ]; then
@@ -101,6 +101,12 @@ _test9() {
     wio update
     wio build
     wio run main --args "15 7"
+}
+
+_test10() {
+    cd ./project-app/app-avr-vendor
+    rm -rf .wio
+    wio install
 }
 
 # Source and build

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -48,6 +48,7 @@ _test2() {
 _test3() {
     cd ./project-pkg/pkg-malloc
     wio clean --hard
+    wio install
     wio update
     wio build
     wio run

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -15,21 +15,21 @@ fi
 # Pre and Post test functions
 _pre() {
     printf "======== RUNNING TEST $1 ========\n"
-    cd $base_folder
-    rm -rf $test_folder
+    cd ${base_folder}
+    rm -rf ${test_folder}
 }
 
 _post() {
     printf "========== DONE TEST $1 =========\n"
     printf "\n"
-    cd $base_folder
-    rm -rf $test_folder
+    cd ${base_folder}
+    rm -rf ${test_folder}
 }
 
 # Functional tests
 _test1() {
-    cp -r ./project-pkg/pkg-fives ./$test_folder
-    cd $test_folder
+    cp -r ./project-pkg/pkg-fives ./${test_folder}
+    cd ${test_folder}
     rm wio.yml
     wio create pkg --platform native --only-config
     wio build
@@ -37,8 +37,8 @@ _test1() {
 }
 
 _test2() {
-    cp -r ./project-pkg/pkg-square ./$test_folder
-    cd $test_folder
+    cp -r ./project-pkg/pkg-square ./${test_folder}
+    cd ${test_folder}
     rm wio.yml
     wio create pkg --platform native --only-config
     wio build
@@ -120,9 +120,9 @@ cd ./tests
 find ./ -maxdepth 3 -name ".wio" -type d -exec rm -rf {} \;
 
 # Run each test
-for i in `seq 1 $num_tests`; do
+for i in `seq 1 ${num_tests}`; do
     test_func="_test$i"
     _pre "$i"
-    $test_func
+    ${test_func}
     _post "$i"
 done

--- a/tests/symlinks.sh
+++ b/tests/symlinks.sh
@@ -13,3 +13,7 @@ ln -s -f $(pwd)/project-pkg/pkg-list $(pwd)/project-app/app-avr/vendor/pkg-list
 mkdir -p $(pwd)/project-pkg/pkg-trace/vendor
 rm -f $(pwd)/project-pkg/pkg-trace/vendor/pkg-uart
 ln -s -f $(pwd)/project-pkg/pkg-uart $(pwd)/project-pkg/pkg-trace/vendor/pkg-uart
+
+mkdir -p $(pwd)/project-app/app-avr-vendor/vendor
+rm -f $(pwd)/project-app/app-avr-vendor/vendor/pkg-list
+ln -s -f $(pwd)/project-pkg/pkg-list $(pwd)/project-app/app-avr-vendor/vendor/pkg-list


### PR DESCRIPTION
This is basically what I did:
1. Ignore vendor dependency from the project dependencies
2. Scan vendor dependencies and create a map of all the remote dependencies in them
3. Merged these dependencies with the project's remote dependencies
4. Then remote fetcher fetches all the remote dependencies
5. Removed path checking for vendor packages (remote fetcher does not know anything about vendor)

More details:
* Remote will fetch all remotes and that is it
* Build process will create a dependency tree and resolve overrides from vendor
* For vendor dependencies, `Dependencies()` returns `vendor<version>` as map value
* For remote dependencies, `Dependencies()` returns `<version>` as map value